### PR TITLE
因为自闭合a标签导致下面的代码无法正常显示

### DIFF
--- a/docs/tutorial/app-push.md
+++ b/docs/tutorial/app-push.md
@@ -100,7 +100,7 @@ var str = dateToStr(new Date());
 str += ": 欢迎使用Html5 Plus创建本地消息！";  
 plus.push.createMessage(str, "LocalMSG", options);  
 ```
-<a id="receive" />
+<a id="receive"></a>
 **iOS平台创建本地消息也会触发监听的"receive"事件，此时需要添加特殊参数来标识本地创建的消息。**
 ```
 // 监听在线消息事件


### PR DESCRIPTION
因为自闭合a标签导致下面的代码无法正常显示，改成<a></a>就可以正常显示了
github正常显示的，但是在官网不正常
![issue](https://github.com/user-attachments/assets/653b28bd-28f9-4caa-9da6-2993d22f1244)
改完后：
![issue_done](https://github.com/user-attachments/assets/1e118e29-c8e3-4a8c-aadf-aad95933e92f)
